### PR TITLE
Allowed users fixes/workarounds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,9 +13,8 @@ electricbook.gz
 src/go/pkg
 test/
 tools/ansible/*.retry
-tools/ansible/hosts-lateral
-tools/ansible/hosts-ebw
 tools/ansible/hosts-*
+!tools/ansible/hosts-example
 electricbook-*.yml
 git_cache/pr_requests/*
 git_cache/repos/*

--- a/docs/_developers/deploy.md
+++ b/docs/_developers/deploy.md
@@ -22,9 +22,9 @@ The Ansible deployment needs a built `bin/electricbook` binary on your local mac
 
 Then go to the `tools/ansible` directory:
 
-1. Copy the `hosts-test` file to a file your own for deployment. E.g.
+1. Copy the `hosts-example` file to a file your own for deployment. E.g.
 
-       cp hosts-test hosts-staging
+       cp hosts-example hosts-staging
 
     Do not commit this file to version control, because it contains confidential information. (It should be ignored already by `.gitignore`.)
 

--- a/electricbook.yml
+++ b/electricbook.yml
@@ -35,5 +35,8 @@ recover_panics: true
 # Add at least your own GitHub username for logging into the EBM.
 # You can also include a list of allowed users per server
 # in your hosts-* files. They will be added to this list.
-allowed_users:
-  - ""
+# If this is uncommented and contains an empty value (""),
+# all users will be allowed (not recommended).
+#
+# allowed_users:
+#   - ""

--- a/electricbook.yml
+++ b/electricbook.yml
@@ -32,9 +32,9 @@ error_mail:
   username: ""
   password: ""
 recover_panics: true
-# Add at least your own GitHub username for logging into the EBM.
-# You can also include a list of allowed users per server
-# in your hosts-* files. They will be added to this list.
+# Uncomment below, and add at least your own GitHub username
+# for logging into your EBM. For deployment to a remote server,
+# include a list of allowed users per server in your hosts-* files.
 # If this is uncommented and contains an empty value (""),
 # all users will be allowed (not recommended).
 #

--- a/src/go/src/ebw/config/Config.go
+++ b/src/go/src/ebw/config/Config.go
@@ -2,8 +2,6 @@ package config
 
 import (
 	"fmt"
-	`bufio`
-	`strings`
 	"io/ioutil"
 	"os"
 
@@ -103,29 +101,6 @@ func (c *config) Load(root string) error {
 			return err
 		}
 		i++
-	}
-	return c.loadAllowedUsers(root)
-}
-
-func (c *config) loadAllowedUsers(root string) error {
-	in, err := os.Open(root + "-users.txt")
-	if nil!=err {
-		if os.IsNotExist(err) {
-			return nil
-		}
-		return err
-	}
-	defer in.Close()
-	scan := bufio.NewScanner(in)
-	if c.AllowedUsers == nil {
-		c.AllowedUsers = []string{}
-	}
-	for scan.Scan() {
-		line := strings.TrimSpace(scan.Text())
-		if 0==len(line) || '#'==line[0] {
-			continue
-		}
-		c.AllowedUsers = append(c.AllowedUsers, line)
 	}
 	return nil
 }

--- a/tools/ansible/hosts-example
+++ b/tools/ansible/hosts-example
@@ -3,9 +3,13 @@
 # If you don't have SSH key access, add ansible_password=yourpasswordhere
 example.com ansible_user=root fqdn=example.com webserver=haproxy
 
-[haproxy]
-# As above, add your EBM's URL as the name for the [haproxy] play
-example.com
+# Below, add your EBM's URL as the name for the [haproxy] play.
+# Uncomment this group (the [haproxy] line and the name below it)
+# just to setup SSL. Then comment it out to avoid renewing
+# the certificate every time you deploy.
+#
+# [haproxy]
+# example.com
 
 [servers:vars]
 bind=8080
@@ -63,9 +67,10 @@ email_from=
 # depending on your email configuration.
 email_insecure_skip_verify=false
 
-# A list of GitHub usernames for allowed users
+# A list of GitHub usernames for allowed users.
 # E.g. this allows all users (not recommended):
 # allowed_users=['.*']
 # while this will allow only these specific users:
 # allowed_users=['craigmj','arthurattwell']
-allowed_users=['.*']
+
+allowed_users=[]

--- a/tools/ansible/roles/electricbook/tasks/main.yml
+++ b/tools/ansible/roles/electricbook/tasks/main.yml
@@ -53,15 +53,6 @@
   become: yes
   notify: 'restart electricbook'
 
-- name: install-allowed-users
-  template: >
-    dest=/opt/electricbook/electricbook-users.txt
-    src=electricbook-users.txt.j2
-    mode=0755
-  become: yes
-  tags: ['allowed-users']
-  notify: 'restart electricbook'
-
 - name: configure upstart for electricbook
   when: >
     ansible_distribution_major_version|int < 16

--- a/tools/ansible/roles/electricbook/templates/electricbook-0.yml.j2
+++ b/tools/ansible/roles/electricbook/templates/electricbook-0.yml.j2
@@ -14,3 +14,7 @@ error_mail:
   to: "{{email_to}}"
   from: "{{email_from}}"
   insecure_skip_verify: {{email_insecure_skip_verify}}
+allowed_users:
+{% for user in allowed_users %}
+  - {{ user }}
+{% endfor %}

--- a/tools/ansible/roles/electricbook/templates/electricbook-users.txt.j2
+++ b/tools/ansible/roles/electricbook/templates/electricbook-users.txt.j2
@@ -1,5 +1,0 @@
-# list of ansible users
-# Put one to a line, # at start of line for comments
-{% for u in allowed_users %}
-{{ u }}
-{% endfor %}


### PR DESCRIPTION
I think this fixes the ability to define an `allowed-users` list in a `hosts-*` file for deployment with Ansible.